### PR TITLE
IDES2-3511 Fixes for Boost v1.72

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@
 
 cmake_minimum_required(VERSION 3.0)
 
-project(owlcpp VERSION 0.3.3.97)
-
 # global definition
 set(CMAKE_CXX_STANDARD 11)
 
@@ -20,6 +18,25 @@ HunterGate(
     URL "xxxxxxxxxx"
     SHA1 "xxxxxxxxxx"
 )
+
+project(owlcpp VERSION 0.3.3.97)
+
+# Handle flags for different boost versions
+if("${HUNTER_Boost_VERSION}" STREQUAL "")
+    if(NOT HUNTER_FINALIZED)
+        include(hunter_finalize)
+        hunter_finalize()
+        set(HUNTER_FINALIZED TRUE)
+    endif()
+endif()
+if(HUNTER_Boost_VERSION VERSION_LESS "1.72.0")
+    add_definitions( -DBOOST_ALL_NO_LIB )
+else()
+    # Boost package now sets the ALL_NO_LIB internally but needs to be
+    # told to use static libraries as the default has changed to shared.
+    set(Boost_USE_STATIC_LIBS ON)
+endif()
+
 
 hunter_add_package(Boost COMPONENTS system)
 find_package(Boost CONFIG REQUIRED system)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -24,6 +24,8 @@ target_compile_definitions(${LIBRARY_NAME} PRIVATE
     "OWLCPP_VERSION_DIRTY=0"
 )
 
+target_link_libraries(${LIBRARY_NAME} Boost::boost)
+
 # Generate public header list.
 file(GLOB LIBRARY_HEADER_FILES
     "${PROJECT_INCLUDE_DIR}/${PROJECT_NAME}/*.hpp"

--- a/lib/io/CMakeLists.txt
+++ b/lib/io/CMakeLists.txt
@@ -47,6 +47,7 @@ target_include_directories(${LIBRARY_NAME} PUBLIC
     $<INSTALL_INTERFACE:> # Project level include directory will do.
 )
 target_link_libraries(${LIBRARY_NAME} PUBLIC
+    Boost::boost
     Boost::filesystem
 )
 target_link_libraries(${LIBRARY_NAME} PRIVATE

--- a/lib/logic/CMakeLists.txt
+++ b/lib/logic/CMakeLists.txt
@@ -44,6 +44,7 @@ target_include_directories(${LIBRARY_NAME} PUBLIC
     $<INSTALL_INTERFACE:> # Project level include directory will do.
 )
 target_link_libraries(${LIBRARY_NAME} PUBLIC
+    Boost::boost
     Boost::system
 )
 target_link_libraries(${LIBRARY_NAME} PRIVATE

--- a/lib/rdf/CMakeLists.txt
+++ b/lib/rdf/CMakeLists.txt
@@ -38,6 +38,7 @@ target_include_directories(${LIBRARY_NAME} PUBLIC
     $<INSTALL_INTERFACE:> # Project level include directory will do.
 )
 target_link_libraries(${LIBRARY_NAME} PUBLIC
+    Boost::boost
     Boost::system
 )
 


### PR DESCRIPTION
Ensure use static boost libraries and appropriate Boost::boost
dependencies.