### PR TITLE
IDES2-3629 Further Boost 1.72 fixes

### DIFF
--- a/include/owlcpp/rdf/map_doc.hpp
+++ b/include/owlcpp/rdf/map_doc.hpp
@@ -262,7 +262,7 @@ private:
       if( is_empty(vers) && path.empty() ) {
          if( const iri_range r = find_iri(iri) ) {
             idp = &(*r.begin());
-            BOOST_ASSERT( distance(r) == 1 );
+            BOOST_ASSERT( boost::distance(r) == 1 );
          }
       }
       return idp;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -24,8 +24,6 @@ target_compile_definitions(${LIBRARY_NAME} PRIVATE
     "OWLCPP_VERSION_DIRTY=0"
 )
 
-target_link_libraries(${LIBRARY_NAME} Boost::boost)
-
 # Generate public header list.
 file(GLOB LIBRARY_HEADER_FILES
     "${PROJECT_INCLUDE_DIR}/${PROJECT_NAME}/*.hpp"

--- a/lib/io/CMakeLists.txt
+++ b/lib/io/CMakeLists.txt
@@ -47,7 +47,6 @@ target_include_directories(${LIBRARY_NAME} PUBLIC
     $<INSTALL_INTERFACE:> # Project level include directory will do.
 )
 target_link_libraries(${LIBRARY_NAME} PUBLIC
-    Boost::boost
     Boost::filesystem
 )
 target_link_libraries(${LIBRARY_NAME} PRIVATE

--- a/lib/logic/CMakeLists.txt
+++ b/lib/logic/CMakeLists.txt
@@ -44,7 +44,6 @@ target_include_directories(${LIBRARY_NAME} PUBLIC
     $<INSTALL_INTERFACE:> # Project level include directory will do.
 )
 target_link_libraries(${LIBRARY_NAME} PUBLIC
-    Boost::boost
     Boost::system
 )
 target_link_libraries(${LIBRARY_NAME} PRIVATE

--- a/lib/rdf/CMakeLists.txt
+++ b/lib/rdf/CMakeLists.txt
@@ -38,7 +38,6 @@ target_include_directories(${LIBRARY_NAME} PUBLIC
     $<INSTALL_INTERFACE:> # Project level include directory will do.
 )
 target_link_libraries(${LIBRARY_NAME} PUBLIC
-    Boost::boost
     Boost::system
 )
 


### PR DESCRIPTION
More changes to ensure this works on IDES2-3629. Backout some no longer required extra targets added in earlier version and fix missing "boost::" in "boost::distance".