### PR TITLE
Ent 2470 update to be compliant with cpp17

### DIFF
--- a/include/owlcpp/detail/object_id_base.hpp
+++ b/include/owlcpp/detail/object_id_base.hpp
@@ -6,6 +6,7 @@ part of owlcpp project.
 #ifndef OBJECT_ID_BASE_HPP_
 #define OBJECT_ID_BASE_HPP_
 #include <iosfwd>
+#include <cstddef>
 #include "boost/cstdint.hpp"
 
 namespace owlcpp{ namespace detail{

--- a/include/owlcpp/rdf/map_node.hpp
+++ b/include/owlcpp/rdf/map_node.hpp
@@ -39,7 +39,7 @@ public:
    typedef Node_id id_type;
    typedef Node node_type;
 private:
-   typedef std::auto_ptr<node_type> ptr_t;
+   typedef std::unique_ptr<node_type> ptr_t;
    typedef boost::ptr_vector<boost::nullable<Node> > vector_t;
    typedef boost::unordered_map<
             Node const*,
@@ -192,7 +192,7 @@ public:
       return insert(Node_blank(n, doc));
    }
 
-   std::auto_ptr<Node> remove(const Node_id id) {
+   std::unique_ptr<Node> remove(const Node_id id) {
       BOOST_ASSERT(find(id));
       const std::size_t n = map_.erase(&get(id));
       boost::ignore_unused_variable_warning(n);

--- a/lib/logic/factpp/expression.hpp
+++ b/lib/logic/factpp/expression.hpp
@@ -64,7 +64,7 @@ template<class T> struct Expression {
    struct Err : public Logic_err {};
    typedef Expression self_t;
    typedef T expression_type;
-   typedef std::auto_ptr<self_t> ptr_t;
+   typedef std::unique_ptr<self_t> ptr_t;
    typedef typename expression_type::fact_type generated_t;
    virtual generated_t get(ReasoningKernel& k) const  = 0;
    virtual std::string string() const {return "Expression";}


### PR DESCRIPTION
Replaced the use of auto_ptr to unique_ptr to be compliant with latest c++ standards.