### PR TITLE
ENT-3325 Further C++17 fixes

### DIFF
--- a/include/owlcpp/rdf/detail/triple_index_map_impl.hpp
+++ b/include/owlcpp/rdf/detail/triple_index_map_impl.hpp
@@ -35,7 +35,7 @@ class Tim_query_dispatch {
    typedef typename config::storage storage;
    typedef typename config::value_type value_type;
 
-   class Equal : public std::unary_function<value_type, bool> {
+   class Equal {
    public:
       explicit Equal(const Q0 q) : q_(q) {}
       bool operator()(value_type const& p) const {return p.first == q_;}

--- a/include/owlcpp/rdf/detail/triple_index_vector_impl.hpp
+++ b/include/owlcpp/rdf/detail/triple_index_vector_impl.hpp
@@ -81,7 +81,7 @@ class Tiv_query_dispatch {
    typedef typename config::id_type id_type;
    typedef typename config::value_type value_type;
 
-   class Equal : public std::unary_function<value_type, bool> {
+   class Equal {
    public:
       explicit Equal(const Q0 q) : q_(q) {}
       bool operator()(value_type const& p) const {return p.first == q_;}

--- a/include/owlcpp/rdf/detail/triple_set.hpp
+++ b/include/owlcpp/rdf/detail/triple_set.hpp
@@ -31,7 +31,7 @@ template<
    class Q1 = typename boost::mpl::at<Triple, Tag1>::type,
    class Q2 = typename boost::mpl::at<Triple, Tag2>::type,
    class Q3 = typename boost::mpl::at<Triple, Tag3>::type
-> struct Value_predicate : public std::unary_function<Triple, bool> {
+> struct Value_predicate {
 public:
    Value_predicate() {}
 


### PR DESCRIPTION
Remove uses of std::unary_function - this was deprecated at C++11
but has been formally removed at C++17. Seems the use was basically
redundant and can just be removed.