### PR TITLE
ENT-12650 Use std::filesystem by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,10 @@
 # Project settings
 ###############################################################################
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.12)
 
 # global definition
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 ###############################################################################
 # Initialize Hunter
@@ -37,6 +37,7 @@ else()
     set(Boost_USE_STATIC_LIBS ON)
 endif()
 
+option(USE_BOOST_FILESYSTEM "Use Boost::filesystem instead of std::filesystem" OFF)
 
 hunter_add_package(Boost COMPONENTS system)
 find_package(Boost CONFIG REQUIRED system)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -8,8 +8,10 @@ set(@PROJECT_NAME@_BUILT_IO @BUILD_IO@)
 set(@PROJECT_NAME@_BUILT_LOGIC @BUILD_LOGIC@)
 
 if(@PROJECT_NAME@_BUILT_IO)
-    hunter_add_package(Boost COMPONENTS filesystem)
-    find_package(Boost CONFIG REQUIRED filesystem)
+    if(@USE_BOOST_FILESYSTEM@)
+        hunter_add_package(Boost COMPONENTS filesystem)
+        find_package(Boost CONFIG REQUIRED filesystem)
+    endif()
 
     hunter_add_package(raptor2)
     find_package(raptor2 CONFIG REQUIRED)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -13,6 +13,10 @@ if(@PROJECT_NAME@_BUILT_IO)
         find_package(Boost CONFIG REQUIRED filesystem)
     endif()
 
+    # libxml2 is required by raptor2
+    hunter_add_package(libxml2)
+    find_package(LibXml2 REQUIRED)
+
     hunter_add_package(raptor2)
     find_package(raptor2 CONFIG REQUIRED)
 endif()

--- a/include/owlcpp/io/catalog.hpp
+++ b/include/owlcpp/io/catalog.hpp
@@ -6,7 +6,7 @@ part of owlcpp project.
 #ifndef CATALOG_HPP_
 #define CATALOG_HPP_
 #include <limits>
-#include "boost/filesystem/path.hpp"
+#include <string>
 
 #include "owlcpp/io/config.hpp"
 #include "owlcpp/io/exception.hpp"
@@ -103,8 +103,6 @@ private:
  and add them to the catalog
  @param cat catalog;
  @param path symbolic path pointing to local file or directory;
- any type implicitly convertible to boost::filesystem::path can be used,
- e.g., std::string, const char*
  @param recurse if true add to catalog files located in sub-directories
  @param search_depth once ontologyIRI declaration is found, stop searching for
  versionIRI declaration after @b search_depth triples
@@ -115,7 +113,7 @@ private:
 *******************************************************************************/
 OWLCPP_IO_DECL std::size_t add(
          Catalog& cat,
-         boost::filesystem::path const& path,
+         const std::string& path,
          const bool recurse = false,
          const std::size_t search_depth = std::numeric_limits<std::size_t>::max()
 );

--- a/include/owlcpp/io/input.hpp
+++ b/include/owlcpp/io/input.hpp
@@ -8,8 +8,6 @@ part of owlcpp project.
 #include <iosfwd>
 #include <string>
 
-#include "boost/filesystem/path.hpp"
-
 #include "owlcpp/io/config.hpp"
 #include "owlcpp/io/exception.hpp"
 #include "owlcpp/io/check_ontology_id.hpp"
@@ -67,7 +65,7 @@ If an exception is thrown, the destination triple store remains unchanged.
 *******************************************************************************/
 OWLCPP_IO_DECL
 void load_file(
-         boost::filesystem::path const& file,
+         const std::string& file,
          Triple_store& store,
          Check_id const& check = Check_id()
 );
@@ -84,7 +82,7 @@ If an exception is thrown, the destination triple store remains unchanged.
 *******************************************************************************/
 OWLCPP_IO_DECL
 void load_file(
-         boost::filesystem::path const& file,
+         const std::string& file,
          Triple_store& store,
          Catalog const& cat,
          Check_id const& check = Check_id()

--- a/include/owlcpp/io/read_ontology_iri.hpp
+++ b/include/owlcpp/io/read_ontology_iri.hpp
@@ -9,8 +9,6 @@ part of owlcpp project.
 #include <string>
 #include <utility>
 
-#include "boost/filesystem/path.hpp"
-
 #include "owlcpp/io/config.hpp"
 
 namespace owlcpp{
@@ -36,7 +34,7 @@ versionIRI declaration after @b search_depth triples
 *******************************************************************************/
 OWLCPP_IO_DECL std::pair<std::string,std::string>
 read_ontology_iri(
-         boost::filesystem::path const& file,
+         const std::string& file,
          const std::size_t search_depth = std::numeric_limits<std::size_t>::max()
 );
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,7 +8,7 @@ set(PROJECT_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/include")
 
 get_filename_component(LIBRARY_NAME "${CMAKE_CURRENT_LIST_DIR}" NAME)
 
-hunter_add_package(BOOST COMPONENTS) # for Boost::headers
+hunter_add_package(Boost COMPONENTS) # for Boost::headers
 find_package(Boost CONFIG REQUIRED)
 if (TARGET Boost::boost AND NOT TARGET Boost::headers)
     # On some configs we get Boost::boost as a target not Boost::headers

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.12)
 
 ###############################################################################
 # Target settings
@@ -8,11 +8,18 @@ set(PROJECT_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/include")
 
 get_filename_component(LIBRARY_NAME "${CMAKE_CURRENT_LIST_DIR}" NAME)
 
+hunter_add_package(BOOST COMPONENTS) # for Boost::headers
+find_package(Boost CONFIG REQUIRED)
+if (TARGET Boost::boost AND NOT TARGET Boost::headers)
+    # On some configs we get Boost::boost as a target not Boost::headers
+    add_library(Boost::headers ALIAS Boost::boost)
+endif()
+
 add_library(${LIBRARY_NAME} OBJECT lib_info.cpp)
 target_include_directories(${LIBRARY_NAME} PRIVATE
     "${PROJECT_INCLUDE_DIR}"
-    "${Boost_INCLUDE_DIR}"
 )
+target_link_libraries(${LIBRARY_NAME} PRIVATE Boost::headers)
 target_compile_definitions(${LIBRARY_NAME} PRIVATE
     "OWLCPP_BUILD=0"
     "OWLCPP_NAME=${PROJECT_NAME}"

--- a/lib/io/CMakeLists.txt
+++ b/lib/io/CMakeLists.txt
@@ -8,7 +8,7 @@ set(BOOST_LIBRARIES_TO_USE) # if list empty will still look for Boost::headers
 if(USE_BOOST_FILESYSTEM)
 list(APPEND BOOST_LIBRARIES_TO_USE filesystem)
 endif()
-hunter_add_package(BOOST COMPONENTS ${BOOST_LIBRARIES_TO_USE})
+hunter_add_package(Boost COMPONENTS ${BOOST_LIBRARIES_TO_USE})
 find_package(Boost CONFIG REQUIRED ${BOOST_LIBRARIES_TO_USE})
 if (TARGET Boost::boost AND NOT TARGET Boost::headers)
     # On some configs we get Boost::boost as a target not Boost::headers

--- a/lib/io/CMakeLists.txt
+++ b/lib/io/CMakeLists.txt
@@ -1,14 +1,26 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.12)
 
 ###############################################################################
 # Third-party libraries
 ###############################################################################
 
-hunter_add_package(Boost COMPONENTS filesystem)
-find_package(Boost CONFIG REQUIRED filesystem)
+set(BOOST_LIBRARIES_TO_USE) # if list empty will still look for Boost::headers
+if(USE_BOOST_FILESYSTEM)
+list(APPEND USE_BOOST_FILESYSTEM filesystem)
+endif()
+hunter_add_package(BOOST COMPONENTS ${BOOST_LIBRARIES_TO_USE})
+find_package(Boost CONFIG REQUIRED ${BOOST_LIBRARIES_TO_USE})
+if (TARGET Boost::boost AND NOT TARGET Boost::headers)
+    # On some configs we get Boost::boost as a target not Boost::headers
+    add_library(Boost::headers ALIAS Boost::boost)
+endif()
 
 hunter_add_package(raptor2)
 find_package(raptor2 CONFIG REQUIRED)
+if(NOT TARGET libxml2::libxml2)
+hunter_add_package(libxml2)
+find_package(LibXml2 REQUIRED) # abnormal case in hunter, finds libxml2::libxml2
+endif()
 
 ###############################################################################
 # Target settings
@@ -47,11 +59,17 @@ target_include_directories(${LIBRARY_NAME} PUBLIC
     $<INSTALL_INTERFACE:> # Project level include directory will do.
 )
 target_link_libraries(${LIBRARY_NAME} PUBLIC
+    Boost::headers
+)
+if(USE_BOOST_FILESYSTEM)
+target_link_libraries(${LIBRARY_NAME} PRIVATE
     Boost::filesystem
 )
+endif()
 target_link_libraries(${LIBRARY_NAME} PRIVATE
     raptor2
 )
+target_include_directories(${LIBRARY_NAME} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/../../shared")
 
 # IO needs core functionality
 add_dependencies(${LIBRARY_NAME} rdf)

--- a/lib/io/CMakeLists.txt
+++ b/lib/io/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.0...3.12)
 
 set(BOOST_LIBRARIES_TO_USE) # if list empty will still look for Boost::headers
 if(USE_BOOST_FILESYSTEM)
-list(APPEND USE_BOOST_FILESYSTEM filesystem)
+list(APPEND BOOST_LIBRARIES_TO_USE filesystem)
 endif()
 hunter_add_package(BOOST COMPONENTS ${BOOST_LIBRARIES_TO_USE})
 find_package(Boost CONFIG REQUIRED ${BOOST_LIBRARIES_TO_USE})
@@ -62,9 +62,8 @@ target_link_libraries(${LIBRARY_NAME} PUBLIC
     Boost::headers
 )
 if(USE_BOOST_FILESYSTEM)
-target_link_libraries(${LIBRARY_NAME} PRIVATE
-    Boost::filesystem
-)
+target_link_libraries(${LIBRARY_NAME} PRIVATE Boost::filesystem)
+target_compile_definitions(${LIBRARY_NAME} PRIVATE USE_BOOST_FILESYSTEM)
 endif()
 target_link_libraries(${LIBRARY_NAME} PRIVATE
     raptor2

--- a/lib/io/CMakeLists.txt
+++ b/lib/io/CMakeLists.txt
@@ -17,10 +17,9 @@ endif()
 
 hunter_add_package(raptor2)
 find_package(raptor2 CONFIG REQUIRED)
-if(NOT TARGET libxml2::libxml2)
+
 hunter_add_package(libxml2)
 find_package(LibXml2 REQUIRED) # abnormal case in hunter, finds libxml2::libxml2
-endif()
 
 ###############################################################################
 # Target settings

--- a/lib/io/input.cpp
+++ b/lib/io/input.cpp
@@ -6,12 +6,14 @@ part of owlcpp project.
 #ifndef OWLCPP_IO_SOURCE
 #define OWLCPP_IO_SOURCE
 #endif
+
+#include "fsystem.hpp"
+
 #include "owlcpp/io/input.hpp"
 
 #include <iostream>
 #include <set>
-#include "boost/filesystem/fstream.hpp"
-#include "boost/filesystem.hpp"
+
 #include "boost/foreach.hpp"
 #include "boost/range/algorithm/copy.hpp"
 
@@ -78,25 +80,25 @@ void load(
 /*
 *******************************************************************************/
 void load_file(
-         boost::filesystem::path const& file,
+         const std::string& file,
          Triple_store& store,
          Check_id const& check
 ) {
-   const std::string cp = canonical(file).string();
-   boost::filesystem::ifstream ifs(cp);
+   const std::string cp = fs::canonical(file).string();
+   ifstream ifs(cp);
    load(ifs, store, cp, check);
 }
 
 /*
 *******************************************************************************/
 void load_file(
-         boost::filesystem::path const& file,
+         const std::string& file,
          Triple_store& store,
          Catalog const& cat,
          Check_id const& check
 ) {
-   const std::string cp = canonical(file).string();
-   boost::filesystem::ifstream ifs(cp);
+   const std::string cp = fs::canonical(file).string();
+   ifstream ifs(cp);
    load(ifs, store, cat, cp, check);
 }
 

--- a/lib/io/read_ontology_iri.cpp
+++ b/lib/io/read_ontology_iri.cpp
@@ -6,7 +6,8 @@ part of owlcpp project.
 #ifndef OWLCPP_IO_SOURCE
 #define OWLCPP_IO_SOURCE
 #endif
-#include "boost/filesystem/fstream.hpp"
+#include "fsystem.hpp"
+
 #include "owlcpp/io/read_ontology_iri.hpp"
 #include "owlcpp/io/raptor_wrapper.hpp"
 #include "raptor_to_iri.hpp"
@@ -28,10 +29,10 @@ std::pair<std::string,std::string> read_ontology_iri(
 /*
 *******************************************************************************/
 std::pair<std::string,std::string> read_ontology_iri(
-         boost::filesystem::path const& file,
+         const std::string& file,
          const std::size_t search_depth
 ) {
-   boost::filesystem::ifstream ifs(file);
+   ifstream ifs(file);
    return read_ontology_iri(ifs, search_depth);
 }
 

--- a/lib/logic/CMakeLists.txt
+++ b/lib/logic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.12)
 
 ###############################################################################
 # Third-party libraries

--- a/lib/rdf/CMakeLists.txt
+++ b/lib/rdf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.12)
 
 ###############################################################################
 # Target settings
@@ -21,7 +21,6 @@ file(GLOB LIBRARY_HEADER_FILES
 add_library(${LIBRARY_NAME} STATIC
     ${LIBRARY_SOURCE_FILES}
     ${LIBRARY_HEADER_FILES}
-    $<TARGET_OBJECTS:lib>
 )
 # Apply Boost naming convention.
 if(Boost_USE_MULTITHREADED)

--- a/shared/fsystem.hpp
+++ b/shared/fsystem.hpp
@@ -5,7 +5,8 @@
 // "fs" is either boost:: or std:: filesystem depending on USE_BOOST_FILESYSTEM
 
 #if USE_BOOST_FILESYSTEM
-#include <boost/filesystem>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
 namespace fs = boost::filesystem;
 using ifstream = boost::filesystem::ifstream;
 #else

--- a/shared/fsystem.hpp
+++ b/shared/fsystem.hpp
@@ -1,0 +1,18 @@
+
+#ifndef FSYSTEM_HPP
+#define FSYSTEM_HPP
+
+// "fs" is either boost:: or std:: filesystem depending on USE_BOOST_FILESYSTEM
+
+#if USE_BOOST_FILESYSTEM
+#include <boost/filesystem>
+namespace fs = boost::filesystem;
+using ifstream = boost::filesystem::ifstream;
+#else
+#include <filesystem>
+#include <fstream>
+namespace fs = std::filesystem;
+using ifstream = std::ifstream;
+#endif
+
+#endif // FSYSTEM_HPP


### PR DESCRIPTION
To help move forward switch to using C++17 as target and use std filesystem that comes with it. Add USE_BOOST_FILESYSTEM that will use boost::filesystem (as previous) in case, but that defaults OFF. Note change in API to pass paths by std::string so whichever filesystem is in use does not bother the calling code.
